### PR TITLE
issue #6: Add capability to view cohor…

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -18,14 +18,20 @@
  * Version details.
  *
  * @package   local_cohort_profile
- * @copyright 2019, Yuriy Yurinskiy <yuriyyurinskiy@yandex.ru>
+ * @copyright 2024, Yuriy Yurinskiy <yuriyyurinskiy@yandex.ru>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2020022201;
-$plugin->requires  = 2018120300;
-$plugin->component = 'local_cohort_profile';
-$plugin->maturity = MATURITY_STABLE;
-$plugin->release = '1.0.5';
+$capabilities = array(
+    'local/cohort_profile:view_cohort_list' => array(
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_USER,
+        'archetypes' => array(
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW,
+        ),
+    ),
+);

--- a/lib.php
+++ b/lib.php
@@ -18,7 +18,7 @@
  * This file contains the code for the plugin integration.
  *
  * @package   local_cohort_profile
- * @copyright 2019, Yuriy Yurinskiy <yuriyyurinskiy@yandex.ru>
+ * @copyright 2024, Yuriy Yurinskiy <yuriyyurinskiy@yandex.ru>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -39,8 +39,18 @@ define('LOCAL_COHORT_PROFILE_COHORT_LIMIT', 10);
  * @return void
  */
 function local_cohort_profile_myprofile_navigation(core_user\output\myprofile\tree $tree, $user, $iscurrentuser, $course) {
-    global $CFG, $DB;
+    global $CFG, $DB, $USER;
     require_once($CFG->dirroot . '/cohort/lib.php');
+
+    $context = context_user::instance($user->id);
+
+    $hascapability = has_capability('local/cohort_profile:view_cohort_list', $context);
+    $ownprofile = $user->id == $USER->id;
+
+    # Don't show if user doesn't have capability or is not viewing their own profile
+    if (!$hascapability && !$ownprofile) {
+      return;
+    }
 
     $showallcohorts = optional_param('showallcohorts', 0, PARAM_INT);
 


### PR DESCRIPTION
**Description:** 
Currently any user can view another user's enrollment in different cohorts. This adds a capability that by default only allows editing teachers, teachers, and managers to view other user's cohorts on their profile pages. Users can still view their own cohorts on their profile.

This can be configured in Moodle site administration settings.